### PR TITLE
working firmware, with iram0 overflow patch

### DIFF
--- a/0001-fix-iram1-overflow-move-bsec-text-to-irom0.patch
+++ b/0001-fix-iram1-overflow-move-bsec-text-to-irom0.patch
@@ -1,0 +1,14 @@
+diff --git a/ports/esp8266/boards/esp8266_common.ld b/ports/esp8266/boards/esp8266_common.ld
+index f40ff1e5f..70c44b843 100644
+--- a/ports/esp8266/boards/esp8266_common.ld
++++ b/ports/esp8266/boards/esp8266_common.ld
+@@ -73,6 +73,9 @@ SECTIONS
+         _irom0_text_start = ABSOLUTE(.);
+         *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text)
+ 
++        /* avoid iram0 overflow with extra BSEC module */
++        *bsec/*.o(.literal* .text*)
++
+         /* Vendor SDK in v2.1.0-7-gb8fd588 started to build these with
+            -ffunction-sections -fdata-sections, and require routing to
+            irom via linker:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ cd micropython
 esp-sdk make -C ports/esp8266 submodules
 # build micropython cross compiler (<1min)
 esp-sdk make -C mpy-cross
+# patch micropython, cf https://github.com/devbis/st7789_mpy/#overflow-of-iram1_0_seg
+git patch ../0001-fix-iram1-overflow-move-bsec-text-to-irom0.patch
 ```
 
 ### Build

--- a/modules/bsec/bsecmodule.c
+++ b/modules/bsec/bsecmodule.c
@@ -1,11 +1,23 @@
 // Include MicroPython API.
 #include "py/runtime.h"
 
+/* Use the following bme680 driver: https://github.com/BoschSensortec/BME68x-Sensor-API/blob/v4.4.6/bme68x.h */
+#include "bme68x.h"
+/* BSEC header files are available in the inc/ folder of the release package */
+#include "bsec_interface.h"
+#include "bsec_datatypes.h"
+
+
 // This is the function which will be called from Python as cbsec.add_ints(a, b).
 STATIC mp_obj_t bsec_add_ints(mp_obj_t a_obj, mp_obj_t b_obj) {
     // Extract the ints from the micropython input objects.
     int a = mp_obj_get_int(a_obj);
     int b = mp_obj_get_int(b_obj);
+
+    struct bme68x_dev bme;
+    int8_t rslt;
+    rslt = bme68x_init(&bme);
+
 
     // Calculate the addition and convert to MicroPython object.
     return mp_obj_new_int(a + b);


### PR DESCRIPTION
Build error was:
```
LINK build-GENERIC/firmware.elf
xtensa-lx106-elf-ld: build-GENERIC/firmware.elf section `.text' will not fit in region `iram1_0_seg'
xtensa-lx106-elf-ld: region `iram1_0_seg' overflowed by 20 bytes
make: *** [Makefile:229: build-GENERIC/firmware.elf] Error 1
```

Solution found here: https://github.com/devbis/st7789_mpy/#overflow-of-iram1_0_seg
=> move new symbols to irom0 at link time